### PR TITLE
ao_wasapi: Use ks.h public abi instead of ksuuid.h

### DIFF
--- a/audio/out/ao_wasapi_utils.c
+++ b/audio/out/ao_wasapi_utils.c
@@ -21,7 +21,7 @@
 #include <wchar.h>
 #include <windows.h>
 #include <errors.h>
-#include <ksguid.h>
+#include <ks.h>
 #include <ksmedia.h>
 #include <avrt.h>
 

--- a/meson.build
+++ b/meson.build
@@ -910,8 +910,10 @@ if sdl2_audio.allowed()
     sources += files('audio/out/ao_sdl.c')
 endif
 
+ksuser = cc.find_library('ksuser', required: get_option('wasapi'))
 wasapi = cc.has_header_symbol('audioclient.h', 'IAudioClient', required: get_option('wasapi'))
-if wasapi
+if ksuser.found() and wasapi
+    dependencies += ksuser
     features += 'wasapi'
     sources += files('audio/out/ao_wasapi.c',
                      'audio/out/ao_wasapi_changenotify.c',

--- a/waftools/fragments/wasapi.c
+++ b/waftools/fragments/wasapi.c
@@ -1,6 +1,9 @@
 #include <malloc.h>
 #include <stdlib.h>
 #include <process.h>
+#include <wchar.h>
+#include <windows.h>
+#include <ks.h>
 #include <audioclient.h>
 #include <endpointvolume.h>
 #include <mmdeviceapi.h>
@@ -10,6 +13,9 @@
       &IID_IAudioRenderClient,
       &IID_IAudioClient,
       &IID_IAudioEndpointVolume,
+      &KSDATAFORMAT_SUBTYPE_PCM,
+      &KSDATAFORMAT_SUBTYPE_IEEE_FLOAT,
+      &KSDATAFORMAT_SPECIFIER_NONE,
     };
 int main(void) {
     return 0;

--- a/wscript
+++ b/wscript
@@ -472,7 +472,7 @@ audio_output_features = [
         'name': '--wasapi',
         'desc': 'WASAPI audio output',
         'deps': 'os-win32 || os-cygwin',
-        'func': check_cc(fragment=load_fragment('wasapi.c')),
+        'func': check_cc(lib=['ksuser'], fragment=load_fragment('wasapi.c')),
     }
 ]
 


### PR DESCRIPTION
ks.h is the pubic api provided by microsoft while ksuuid.h
is undocumented.

To use ks.h api, we need to link against ksuser library. So
add ksuer detection to waf and meson.

Fixes: #9627

Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>

Read this before you submit this pull request:
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md

Reading this link and following the rules will get your pull request reviewed
and merged faster. Nobody wants lazy pull requests.